### PR TITLE
Using author profile image instead of cover image for Open Graph

### DIFF
--- a/core/frontend/meta/cover_image.js
+++ b/core/frontend/meta/cover_image.js
@@ -6,9 +6,13 @@ function getCoverImage(data) {
     const context = data.context ? data.context : null;
     const contextObject = getContextObject(data, context);
 
-    if (_.includes(context, 'home') || _.includes(context, 'author')) {
+    if (_.includes(context, 'home')) {
         if (contextObject.cover_image) {
             return urlUtils.urlFor('image', {image: contextObject.cover_image}, true);
+        }
+    } else if (_.includes(context, 'author')) {
+        if (contextObject.profile_image) {
+            return urlUtils.urlFor('image', {image: contextObject.profile_image}, true);
         }
     } else {
         if (contextObject.feature_image) {

--- a/core/frontend/meta/og_image.js
+++ b/core/frontend/meta/og_image.js
@@ -20,8 +20,8 @@ function getOgImage(data) {
         }
     }
 
-    if (_.includes(context, 'author') && contextObject.cover_image) {
-        return urlUtils.relativeToAbsolute(contextObject.cover_image);
+    if (_.includes(context, 'author') && contextObject.profile_image) {
+        return urlUtils.relativeToAbsolute(contextObject.profile_image);
     }
 
     if (_.includes(context, 'tag')) {

--- a/core/frontend/meta/twitter_image.js
+++ b/core/frontend/meta/twitter_image.js
@@ -20,8 +20,8 @@ function getTwitterImage(data) {
         }
     }
 
-    if (_.includes(context, 'author') && contextObject.cover_image) {
-        return urlUtils.relativeToAbsolute(contextObject.cover_image);
+    if (_.includes(context, 'author') && contextObject.profile_image) {
+        return urlUtils.relativeToAbsolute(contextObject.profile_image);
     }
 
     if (_.includes(context, 'tag')) {

--- a/test/unit/data/meta/cover_image_spec.js
+++ b/test/unit/data/meta/cover_image_spec.js
@@ -13,11 +13,11 @@ describe('getCoverImage', function () {
         coverImageUrl.should.match(/\/content\/images\/my-test-image\.jpg$/);
     });
 
-    it('should return absolute cover image url for author', function () {
+    it('should return absolute profile image url for author', function () {
         const coverImageUrl = getCoverImage({
             context: ['author'],
             author: {
-                cover_image: '/content/images/my-test-image.jpg'
+                profile_image: '/content/images/my-test-image.jpg'
             }
         });
         coverImageUrl.should.not.equal('/content/images/my-test-image.jpg');

--- a/test/unit/data/meta/og_image_spec.js
+++ b/test/unit/data/meta/og_image_spec.js
@@ -113,13 +113,13 @@ describe('getOgImage', function () {
         localSettingsCache.cover_image = '/content/images/settings-cover.jpg';
 
         const author = {
-            cover_image: '/content/images/author-cover.jpg'
+            profile_image: '/content/images/author-cover.jpg'
         };
 
         getOgImage({context: ['author'], author})
             .should.endWith('author-cover.jpg');
 
-        author.cover_image = '';
+        author.profile_image = '';
 
         should(
             getOgImage({context: ['author'], author})
@@ -131,13 +131,13 @@ describe('getOgImage', function () {
         localSettingsCache.cover_image = '/content/images/settings-cover.jpg';
 
         const author = {
-            cover_image: '/content/images/author-cover.jpg'
+            profile_image: '/content/images/author-cover.jpg'
         };
 
         getOgImage({context: ['author', 'paged'], author})
             .should.endWith('author-cover.jpg');
 
-        author.cover_image = '';
+        author.profile_image = '';
 
         should(
             getOgImage({context: ['author', 'paged'], author})

--- a/test/unit/data/meta/twitter_image_spec.js
+++ b/test/unit/data/meta/twitter_image_spec.js
@@ -113,13 +113,13 @@ describe('getTwitterImage', function () {
         localSettingsCache.cover_image = '/content/images/settings-cover.jpg';
 
         const author = {
-            cover_image: '/content/images/author-cover.jpg'
+            profile_image: '/content/images/author-cover.jpg'
         };
 
         getTwitterImage({context: ['author'], author})
             .should.endWith('author-cover.jpg');
 
-        author.cover_image = '';
+        author.profile_image = '';
 
         should(
             getTwitterImage({context: ['author'], author})
@@ -131,13 +131,13 @@ describe('getTwitterImage', function () {
         localSettingsCache.cover_image = '/content/images/settings-cover.jpg';
 
         const author = {
-            cover_image: '/content/images/author-cover.jpg'
+            profile_image: '/content/images/author-cover.jpg'
         };
 
         getTwitterImage({context: ['author', 'paged'], author})
             .should.endWith('author-cover.jpg');
 
-        author.cover_image = '';
+        author.profile_image = '';
 
         should(
             getTwitterImage({context: ['author', 'paged'], author})

--- a/test/unit/helpers/ghost_head_spec.js
+++ b/test/unit/helpers/ghost_head_spec.js
@@ -1157,7 +1157,7 @@ describe('{{ghost_head}} helper', function () {
             }).catch(done);
         });
 
-        it('returns structured data and schema on first author page with cover image', function (done) {
+        it('returns structured data and schema on first author page with profile image', function (done) {
             helpers.ghost_head(testUtils.createHbsResponse({
                 renderObject: {author: users[0]},
                 locals: {


### PR DESCRIPTION
PR Description:

This is the result when trying to debug the author URL when the author hasn't a cover image uploaded.

![Screen Shot 2020-08-05 at 10 06 41 AM](https://user-images.githubusercontent.com/44909285/89389082-3d365280-d705-11ea-8e13-3245886506e3.png)

Since the cover image for the author not important as his/her profile image so I replaced the image that should show up in "og:image" field for Open Graph it makes more sense the authors are giving their profile image higher priority more than cove images,

I am using ghost for publishing I've too many authors they didn't even notice the cover to upload it at the first point, also there is no point of showing there covers instead of the profile picture for social media such as Facebook and Twitter, etc ...

tests also updated.

Thanks